### PR TITLE
Enable multi-date selection in calendar, allow only available class dates, and fix month sync/filter bugs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "react-dom": "19.0.0",
         "react-native": "0.79.2",
         "react-native-gesture-handler": "~2.24.0",
+        "react-native-modal": "^14.0.0-rc.1",
         "react-native-reanimated": "~3.17.4",
         "react-native-safe-area-context": "5.4.0",
         "react-native-screens": "~4.10.0",
@@ -8379,6 +8380,23 @@
         "node": ">= 6"
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -8618,6 +8636,15 @@
         }
       }
     },
+    "node_modules/react-native-animatable": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/react-native-animatable/-/react-native-animatable-1.4.0.tgz",
+      "integrity": "sha512-DZwaDVWm2NBvBxf7I0wXKXLKb/TxDnkV53sWhCvei1pRyTX3MVFpkvdYBknNBqPrxYuAIlPxEp7gJOidIauUkw==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.8.1"
+      }
+    },
     "node_modules/react-native-css-interop": {
       "version": "0.1.22",
       "resolved": "https://registry.npmjs.org/react-native-css-interop/-/react-native-css-interop-0.1.22.tgz",
@@ -8689,6 +8716,19 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/react-native-modal": {
+      "version": "14.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/react-native-modal/-/react-native-modal-14.0.0-rc.1.tgz",
+      "integrity": "sha512-v5pvGyx1FlmBzdHyPqBsYQyS2mIJhVmuXyNo5EarIzxicKhuoul6XasXMviGcXboEUT0dTYWs88/VendojPiVw==",
+      "license": "MIT",
+      "dependencies": {
+        "react-native-animatable": "1.4.0"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": ">=0.70.0"
       }
     },
     "node_modules/react-native-reanimated": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "react-dom": "19.0.0",
     "react-native": "0.79.2",
     "react-native-gesture-handler": "~2.24.0",
+    "react-native-modal": "^14.0.0-rc.1",
     "react-native-reanimated": "~3.17.4",
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "~4.10.0",


### PR DESCRIPTION
## 주요 작업
1. 날짜 중복 선택 기능 추가
- 여러 날짜를 동시에 선택가능
- 선택한 날짜 배열(selectedDates)을 기반으로 필터링 및 UI 반영.
2. 캘린더 필터링 기능 추가
- 상단의 월/연도 및 달력 모달에서 원하는 날짜를 직접 선택하여 요가 클래스를 필터링
- tailwind CSS로 커스텀 캘린더 구현.
3. 실제 요가 클래스가 있는 날짜만 선택 가능
- 달력에서 실제로 요가 클래스가 열리는 날짜만 활성화
- 수업이 없는 날짜는 disable
## 기존 버그 수정
1. 월/연도 동기화 문제
- 날짜 스크롤 시, 월이 넘어가도 상단에 표시되는 월/연도가 바뀌지 않는 버그픽스
2. 잘못된 날짜 필터링 문제
예) 6월 21일을 선택해도 7월 21일에 진행되는 요가 클래스가 같이 필터링되는 이슈
→ 기존에는 '일(day)'만 비교해서 발생한 문제로, '연/월/일' 전체를 비교하도록 로직을 수정하여 정확하게 필터링되도록 개선
